### PR TITLE
Refactor for docker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,4 @@ if(BUILD_KAFKA_PLUGIN)
 else()
   message("kafka_plugin not selected and will be omitted.")
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,16 @@
 #if(BUILD_KAFKA_PLUGIN)
-  file(GLOB HEADERS "include/eosio/mongo_db_plugin/*.hpp")
-  include_directories("/usr/local/include/librdkafka")
-  LINK_LIBRARIES("/usr/local/lib/librdkafka.so" "/usr/local/lib/librdkafka.so.1")
-  link_directories("/usr/local/lib")
+  include(FindPkgConfig)
+  pkg_search_module(RDKAFKA REQUIRED rdkafka)
+
   add_library( kafka_plugin
                kafka_plugin.cpp kafka_producer.cpp
                ${HEADERS} )
-target_include_directories(kafka_plugin
-          PUBLIC "include"
+  target_include_directories(kafka_plugin
+	  PUBLIC "include" ${RDKAFKA_INCLUDE_DIRS}
           )
   target_link_libraries(kafka_plugin
-          PUBLIC chain_plugin eosio_chain appbase fc
+	  PUBLIC chain_plugin eosio_chain appbase fc ${RDKAFKA_LIBRARIES}
           )
-
-  message("mongo_db_plugin not selected and will be omitted.")
+else()
+  message("kafka_plugin not selected and will be omitted.")
 #endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(BUILD_KAFKA_PLUGIN)
                kafka_plugin.cpp kafka_producer.cpp
                ${HEADERS} )
   target_include_directories(kafka_plugin
-	  PUBLIC "include" ${RDKAFKA_INCLUDE_DIRS}
+	  PUBLIC "include" ${RDKAFKA_INCLUDEDIR}/librdkafka
           )
   target_link_libraries(kafka_plugin
 	  PUBLIC chain_plugin eosio_chain appbase fc ${RDKAFKA_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-#if(BUILD_KAFKA_PLUGIN)
+if(BUILD_KAFKA_PLUGIN)
   include(FindPkgConfig)
   pkg_search_module(RDKAFKA REQUIRED rdkafka)
 
@@ -13,4 +13,4 @@
           )
 else()
   message("kafka_plugin not selected and will be omitted.")
-#endif()
+endif()

--- a/include/eosio/kafka_plugin/kafka_producer.hpp
+++ b/include/eosio/kafka_plugin/kafka_producer.hpp
@@ -13,6 +13,8 @@ namespace eosio {
 #define KAFKA_TRX_ACCEPT 0
 #define KAFKA_TRX_APPLIED 1
 
+using MessageCallbackFunctionPtr = void (*)(rd_kafka_t *rk, const rd_kafka_message_t * rkmessage, void *opaque);
+
 class kafka_producer {
     public:
         kafka_producer() {
@@ -25,7 +27,7 @@ class kafka_producer {
             applied_conf = NULL;
         };
 
-        int trx_kafka_init(char *brokers, char *acceptopic, char *appliedtopic);
+        int trx_kafka_init(char *brokers, char *acceptopic, char *appliedtopic, MessageCallbackFunctionPtr msgDeliveredCallback);
 
         int trx_kafka_sendmsg(int trxtype, char *msgstr, const std::string& msgKey);
 
@@ -39,7 +41,6 @@ class kafka_producer {
         rd_kafka_conf_t *accept_conf;     /*kafka config*/
         rd_kafka_conf_t *applied_conf;     /*kafka config*/
 
-        static void dr_msg_cb(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque){}
     };
 }
 

--- a/include/eosio/kafka_plugin/kafka_producer.hpp
+++ b/include/eosio/kafka_plugin/kafka_producer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "rdkafka.h"
 
 namespace eosio {
@@ -25,7 +27,7 @@ class kafka_producer {
 
         int trx_kafka_init(char *brokers, char *acceptopic, char *appliedtopic);
 
-        int trx_kafka_sendmsg(int trxtype, char *msgstr);
+        int trx_kafka_sendmsg(int trxtype, char *msgstr, const std::string& msgKey);
 
         int trx_kafka_destroy(void);
 

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -405,9 +405,13 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
        sstream << last_sent_act_id;
 
        uint64_t time = (t.block_time.time_since_epoch().count()/1000);
-            string transaction_metadata_json =
+       auto &chain = chain_plug->chain();
+       fc::variant tracesVar = chain.to_variant_with_abi(t.trace, chain_plug->get_abi_serializer_max_time());
+
+       string transaction_metadata_json =
                     "{\"block_number\":" + std::to_string(t.block_number) + ",\"block_time\":" + std::to_string(time) +
-                    ",\"trace\":" + fc::json::to_string(t.trace).c_str() + "}";
+                    ",\"trace\":" + fc::json::to_string(tracesVar).c_str() + "}";
+
        producer->trx_kafka_sendmsg(KAFKA_TRX_APPLIED,
                                    (char*)transaction_metadata_json.c_str(),
                                    sstream.str());

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -123,6 +123,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
         kafka_producer_ptr producer;
         const uint64_t KAFKA_BLOCK_REACHED_LOG_INTERVAL = 1000;
         uint64_t kafkaBlockReached = 0;
+        static bool kafkaTriggeredQuit;
     };
 
     const account_name kafka_plugin_impl::newaccount = "newaccount";
@@ -134,7 +135,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
     const std::string kafka_plugin_impl::trans_traces_col = "transaction_traces";
     const std::string kafka_plugin_impl::actions_col = "actions";
     const std::string kafka_plugin_impl::accounts_col = "accounts";
-
+    bool kafka_plugin_impl::kafkaTriggeredQuit = false;
 
     namespace {
 
@@ -475,9 +476,14 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
     }
 
     void kafka_plugin_impl::handle_kafka_exception() {
+        // Trigger quit once only
+        if(kafkaTriggeredQuit) {
+            return;
+        }
         // For the time being quit on all
         elog( "Kafka plugin triggers Quit due to error.");
         app().quit();
+        kafkaTriggeredQuit = true;
     }
 
     void kafka_plugin_impl::kafkaCallbackFunction(rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *opaque) {

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -408,7 +408,8 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
 
     void filterSetcodeData(vector<chain::action_trace>& vecActions) {
         for(auto& actTrace : vecActions) {
-            if("setcode" == actTrace.act.name.to_string()) {
+            if("setcode" == actTrace.act.name.to_string() &&
+                "eosio" == actTrace.act.account.to_string()) {
                 chain::setcode sc = actTrace.act.data_as<chain::setcode>();
                 sc.code.clear();
                 actTrace.act.data = fc::raw::pack(sc);
@@ -507,9 +508,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
         if(nullptr == rkmessage ||
            0 != rkmessage->err )
         {
-            //std::string errorMsg (static_cast<const char*>(rkmessage->payload), rkmessage->len);
-            std::string errorMsg;
-            elog( "Kafka producer callback sent error: ${e}", ("e", errorMsg));
+            elog("Kafka message delivery failed: ${e}", ("e", rd_kafka_err2str(rkmessage->err)));
             handle_kafka_exception();
         }
     }

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -225,7 +225,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
     void kafka_plugin_impl::consume_blocks() {
         try {
 
-            while (true) {
+            while (true && !app().is_quiting()) {
                 boost::mutex::scoped_lock lock(mtx);
                 while (transaction_metadata_queue.empty() &&
                        transaction_trace_queue.empty() &&
@@ -438,6 +438,11 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
        sstream << last_sent_act_id;
 
        uint64_t time = (t.block_time.time_since_epoch().count()/1000);
+
+       // If the application is quitting it is unsafe to touch the chain_plugin. Return.
+       if(app().is_quiting()) {
+           return;
+       }
        auto &chain = chain_plug->chain();
        fc::variant tracesVar = chain.to_variant_with_abi(t.trace, chain_plug->get_abi_serializer_max_time());
 

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -402,8 +402,6 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
        auto last_sent_act_id = getLastActionID(actionTraces);
 
        std::stringstream sstream;
-       sstream << actionTraces[0].receipt.global_sequence;
-       sstream << ".";
        sstream << last_sent_act_id;
 
        uint64_t time = (t.block_time.time_since_epoch().count()/1000);

--- a/kafka_producer.cpp
+++ b/kafka_producer.cpp
@@ -130,8 +130,9 @@ namespace eosio {
                 if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
                     rd_kafka_poll(rk, 1000);
                     shouldRetry = true;
-                }
-                else {
+                } else if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE) {
+                    fprintf(stderr, "The failed message is: \n %.*s ", static_cast<int>(len), msgstr);
+                } else {
                     // Any other error - is not OK
                     throw std::runtime_error("Error on Kafka - send message");
                 }

--- a/kafka_producer.cpp
+++ b/kafka_producer.cpp
@@ -53,8 +53,10 @@ namespace eosio {
             // This pointer is to be freed by rd_kafka_new below
             applied_conf = rd_kafka_conf_new();
 
-            char bufMsgInFlight[16];
-            snprintf(bufMsgInFlight, sizeof(bufMsgInFlight), "%i", 1);
+            //char bufMsgInFlight[16];
+            //snprintf(bufMsgInFlight, sizeof(bufMsgInFlight), "%i", 1);
+            //char bufMsgMaxBytes[16];
+            //snprintf(bufMsgMaxBytes, sizeof(bufMsgMaxBytes), "%i", 3000000);
 
             const char* bufCompression = "lz4";
             const char* bufIdempotent = "true";
@@ -64,7 +66,10 @@ namespace eosio {
                 (rd_kafka_conf_set(applied_conf, "compression.codec", bufCompression, errstr,
                                                   sizeof(errstr)) != RD_KAFKA_CONF_OK) ||
                 (rd_kafka_conf_set(applied_conf, "enable.idempotence", bufIdempotent, errstr,
-                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK))
+                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK)
+                    /*||
+                (rd_kafka_conf_set(applied_conf, "message.max.bytes", bufMsgMaxBytes, errstr,
+                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK)*/ )
             {
                 fprintf(stderr, "%s\n", errstr);
                 return KAFKA_STATUS_INIT_FAIL;

--- a/kafka_producer.cpp
+++ b/kafka_producer.cpp
@@ -22,13 +22,8 @@ namespace eosio {
 
             accept_conf = rd_kafka_conf_new();
 
-            char buf[16];
-            snprintf(buf, sizeof(buf), "%i", 1);
-
-            if ((rd_kafka_conf_set(accept_conf, "bootstrap.servers", brokers, errstr,
-                                  sizeof(errstr)) != RD_KAFKA_CONF_OK) ||
-                (rd_kafka_conf_set(accept_conf, "max.in.flight.requests.per.connection", buf, errstr,
-                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK))
+            if (rd_kafka_conf_set(accept_conf, "bootstrap.servers", brokers, errstr,
+                                  sizeof(errstr)) != RD_KAFKA_CONF_OK)
             {
                 fprintf(stderr, "%s\n", errstr);
                 return KAFKA_STATUS_INIT_FAIL;
@@ -56,8 +51,19 @@ namespace eosio {
 
             applied_conf = rd_kafka_conf_new();
 
-            if (rd_kafka_conf_set(applied_conf, "bootstrap.servers", brokers, errstr,
-                                  sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+            char bufMsgInFlight[16];
+            snprintf(bufMsgInFlight, sizeof(bufMsgInFlight), "%i", 1);
+
+            const char* bufCompression = "lz4";
+            const char* bufIdempotent = "true";
+
+            if ((rd_kafka_conf_set(applied_conf, "bootstrap.servers", brokers, errstr,
+                                  sizeof(errstr)) != RD_KAFKA_CONF_OK) ||
+                (rd_kafka_conf_set(applied_conf, "compression.codec", bufCompression, errstr,
+                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK) ||
+                (rd_kafka_conf_set(applied_conf, "enable.idempotence", bufIdempotent, errstr,
+                                                  sizeof(errstr)) != RD_KAFKA_CONF_OK))
+            {
                 fprintf(stderr, "%s\n", errstr);
                 return KAFKA_STATUS_INIT_FAIL;
             }

--- a/kafka_producer.cpp
+++ b/kafka_producer.cpp
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <string.h>
 #include <stdexcept>
+#include <unistd.h>
 
 #include <eosio/kafka_plugin/kafka_producer.hpp>
 
@@ -116,6 +117,8 @@ namespace eosio {
         }
 
         bool shouldRetry = false;
+        int retryAttemptsLeft = 10;
+        unsigned sleepBetweenRetriesMilliSeconds = 1000;
 
         do {
             int rdKafkaProduceResult = rd_kafka_produce(
@@ -132,9 +135,12 @@ namespace eosio {
                         rd_kafka_topic_name(rkt),
                         rd_kafka_err2str(rd_kafka_last_error()));
 
-                if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
-                    rd_kafka_poll(rk, 1000);
+                if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL &&
+                        retryAttemptsLeft > 0) {
+                    rd_kafka_poll(rk, 0);
                     shouldRetry = true;
+                    --retryAttemptsLeft;
+                    usleep(sleepBetweenRetriesMilliSeconds * 1000);
                 } else if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE) {
                     fprintf(stderr, "The failed message is: \n %.*s ", static_cast<int>(len), msgstr);
                 } else {
@@ -173,155 +179,5 @@ namespace eosio {
         return KAFKA_STATUS_OK;
     }
 }
-#if 0
-int main(int argc, char **argv)
-{
-	char buf[512]; 
-	int kafkastaus=KAFKA_STATUS_OK;
-	trx_kafka_init();
-	
-	
-	fprintf(stderr,
-                "%% Type some text and hit enter to produce message\n"
-                "%% Or just hit enter to only serve delivery reports\n"
-                "%% Press Ctrl-C or Ctrl-D to exit\n");
-	while(run && fgets(buf, sizeof(buf), stdin))
-	{
-		do{
-			kafkastaus=trx_kafka_sendmsg(buf);
-		}while(kafkastaus==KAFKA_STATUS_QUEUE_FULL);
-	}
 
-	trx_kafka_destroy();
-}
-#endif
-
-#if 0
-int main(int argc, char **argv){
-	rd_kafka_t *rk;            /*Producer instance handle*/
-	rd_kafka_topic_t *rkt;     /*topic对象*/
-	rd_kafka_conf_t *conf;     /*临时配置对象*/
-	char errstr[512];          
-	char buf[512];             
-	const char *brokers;       
-	const char *topic;         
- 
-	if(argc != 3){
-		fprintf(stderr, "%% Usage: %s <broker> <topic>\n", argv[0]);
-        return 1;
-	}
- 
-	brokers = argv[1];
-	topic = argv[2];
- 
-    /* 创建一个kafka配置占位 */
-	conf = rd_kafka_conf_new();
- 
-    /*创建broker集群*/
-	if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, errstr,
-				sizeof(errstr)) != RD_KAFKA_CONF_OK){
-		fprintf(stderr, "%s\n", errstr);
-		return 1;
-	}
- 
-    /*设置发送报告回调函数，rd_kafka_produce()接收的每条消息都会调用一次该回调函数
-     *应用程序需要定期调用rd_kafka_poll()来服务排队的发送报告回调函数*/
-	rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
- 
-    /*创建producer实例
-      rd_kafka_new()获取conf对象的所有权,应用程序在此调用之后不得再次引用它*/
-	rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-	if(!rk){
-		fprintf(stderr, "%% Failed to create new producer:%s\n", errstr);
-		return 1;
-	}
- 
-    /*实例化一个或多个topics(`rd_kafka_topic_t`)来提供生产或消费，topic
-    对象保存topic特定的配置，并在内部填充所有可用分区和leader brokers，*/
-	rkt = rd_kafka_topic_new(rk, topic, NULL);
-	if (!rkt){
-		fprintf(stderr, "%% Failed to create topic object: %s\n", 
-				rd_kafka_err2str(rd_kafka_last_error()));
-		rd_kafka_destroy(rk);
-		return 1;
-	}
- 
-    /*用于中断的信号*/
-	signal(SIGINT, stop);
- 
-	fprintf(stderr,
-                "%% Type some text and hit enter to produce message\n"
-                "%% Or just hit enter to only serve delivery reports\n"
-                "%% Press Ctrl-C or Ctrl-D to exit\n");
- 
-     while(run && fgets(buf, sizeof(buf), stdin)){
-     	size_t len = strlen(buf);
- 
-     	if(buf[len-1] == '\n')
-     		buf[--len] = '\0';
- 
-     	if(len == 0){
-            /*轮询用于事件的kafka handle，
-            事件将导致应用程序提供的回调函数被调用
-            第二个参数是最大阻塞时间，如果设为0，将会是非阻塞的调用*/
-     		rd_kafka_poll(rk, 0);
-     		continue;
-     	}
- 
-     retry:
-         /*Send/Produce message.
-           这是一个异步调用，在成功的情况下，只会将消息排入内部producer队列，
-           对broker的实际传递尝试由后台线程处理，之前注册的传递回调函数(dr_msg_cb)
-           用于在消息传递成功或失败时向应用程序发回信号*/
-     	if (rd_kafka_produce(
-                    /* Topic object */
-     				rkt,
-                    /*使用内置的分区来选择分区*/
-     				RD_KAFKA_PARTITION_UA,
-                    /*生成payload的副本*/
-     				RD_KAFKA_MSG_F_COPY,
-                    /*消息体和长度*/
-     				buf, len,
-                    /*可选键及其长度*/
-     				NULL, 0,
-     				NULL) == -1){
-     		fprintf(stderr, 
-     			"%% Failed to produce to topic %s: %s\n", 
-     			rd_kafka_topic_name(rkt),
-     			rd_kafka_err2str(rd_kafka_last_error()));
- 
-     		if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL){
-                /*如果内部队列满，等待消息传输完成并retry,
-                内部队列表示要发送的消息和已发送或失败的消息，
-                内部队列受限于queue.buffering.max.messages配置项*/
-     			rd_kafka_poll(rk, 1000);
-     			goto retry;
-     		}	
-     	}else{
-     		fprintf(stderr, "%% Enqueued message (%zd bytes) for topic %s\n", 
-     			len, rd_kafka_topic_name(rkt));
-     	}
- 
-        /*producer应用程序应不断地通过以频繁的间隔调用rd_kafka_poll()来为
-        传送报告队列提供服务。在没有生成消息以确定先前生成的消息已发送了其
-        发送报告回调函数(和其他注册过的回调函数)期间，要确保rd_kafka_poll()
-        仍然被调用*/
-     	rd_kafka_poll(rk, 0);
-     }
- 
-     fprintf(stderr, "%% Flushing final message.. \n");
-     /*rd_kafka_flush是rd_kafka_poll()的抽象化，
-     等待所有未完成的produce请求完成，通常在销毁producer实例前完成
-     以确保所有排列中和正在传输的produce请求在销毁前完成*/
-     rd_kafka_flush(rk, 10*1000);
- 
-     /* Destroy topic object */
-     rd_kafka_topic_destroy(rkt);
- 
-     /* Destroy the producer instance */
-     rd_kafka_destroy(rk);
- 
-     return 0;
-}
-#endif
 

--- a/kafka_producer.cpp
+++ b/kafka_producer.cpp
@@ -6,9 +6,9 @@
 
  
 /*
-    每条消息调用一次该回调函数，说明消息是传递成功(rkmessage->err == RD_KAFKA_RESP_ERR_NO_ERROR)
-    还是传递失败(rkmessage->err != RD_KAFKA_RESP_ERR_NO_ERROR)
-    该回调函数由rd_kafka_poll()触发，在应用程序的线程上执行
+    The callback function is called once for each message, indicating that the message was successfully delivered (rkmessage->err == RD_KAFKA_RESP_ERR_NO_ERROR)
+    Still failed to pass (rkmessage->err != RD_KAFKA_RESP_ERR_NO_ERROR)
+    The callback function is triggered by rd_kafka_poll() and executed on the thread of the application.
  */
 namespace eosio {
 


### PR DESCRIPTION
Various changes done on the Kafka plugin.

- Exit the Node when Kafka producer reports most errors. Only log on 'msg too large' error.
- Add unique, incrementing keys to Kafka messages, based on action IDs.
- Omit 'code' data, inside 'setcode' actions. Such messages was causing errors in the Kafka broker.
- LZ4 compression enabled in producer
- Use PkgConfig for build system
- Logging added
- Style changes