### PR TITLE
Send EOS transaction to Kafka once the block is irreversible

### DIFF
--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -419,7 +419,8 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
 
      void kafka_plugin_impl::_process_applied_transaction(const trasaction_info_st &t) {
        if(t.trace->action_traces.empty()) {
-           dlog("Apply transaction is skipped. No actions inside. Block number is: ${block_number}",
+           dlog("Apply transaction with id: ${id} is skipped. No actions inside. Block number is: ${block_number}",
+                ("id", t.trace->id.str())
                 ("block_number", t.block_number));
            return;
        }

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -447,6 +447,9 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
        for(const chain::transaction_receipt& receipt : trxReceipts) {
            transaction_id_type trxId;
 
+           if(receipt.status != chain::transaction_receipt_header::executed) {
+               continue;
+           }
            if( receipt.trx.contains<packed_transaction>() ) {
               const auto& pt = receipt.trx.get<packed_transaction>();
               // get id via get_raw_transaction() as packed_transaction.id() mutates internal transaction state

--- a/kafka_plugin.cpp
+++ b/kafka_plugin.cpp
@@ -53,6 +53,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
         prometheus::Gauge& blockGauge;
         prometheus::Gauge& abnormalityBlockGauge;
         prometheus::Gauge& pendingBlocksGauge;
+        prometheus::Gauge& oldestPendingBlockGauge;
     public:
         PrometheusExposer(const std::string& hostPort)
             :
@@ -67,7 +68,9 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
             abnormalityBlockGauge(gaugeFamily.Add(
                 {{"name", "abnormalityBlockCounter"}})),
             pendingBlocksGauge(gaugeFamily.Add(
-              {{"name", "pendingBlocksCounter"}}))
+              {{"name", "pendingBlocksCounter"}})),
+            oldestPendingBlockGauge(gaugeFamily.Add(
+              {{"name", "oldestPendingBlock"}}))
         {
             exposer.RegisterCollectable(registry);
         }
@@ -80,6 +83,9 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
         }
         prometheus::Gauge& getPendingBlocksGauge() {
             return pendingBlocksGauge;
+        }
+        prometheus::Gauge& getOldestPendingBlockGauge() {
+            return oldestPendingBlockGauge;
         }
     };
 
@@ -511,6 +517,7 @@ using kafka_producer_ptr = std::shared_ptr<class kafka_producer>;
         }
 
         prometheusExposer->getPendingBlocksGauge().Set(appliedTrxPerBlock.size());
+        prometheusExposer->getOldestPendingBlockGauge().Set(appliedTrxPerBlock.empty() ? 0 : appliedTrxPerBlock.begin()->first);
     }
 
     kafka_plugin_impl::kafka_plugin_impl()


### PR DESCRIPTION
* When the transactions are are reported as 'applied', just store them. Once the block is reported as 'irreversible', then send them to Kafka
* Removed unused code 